### PR TITLE
Adding how to install on windows.

### DIFF
--- a/install-windows.md
+++ b/install-windows.md
@@ -18,7 +18,7 @@ If the code `import sphinx` does not raise a
 with the section *compile the script*.
 
 If `sphinx` is not installed run the code 
-`pip install sphinx` (or `conda install sphinx if you have 
+`pip install sphinx` (or `conda install sphinx` if you have 
 python installed via anaconda. To find out if you are using 
 conda type `conda list` in the command line. If there is an 
 error you are *not* using anaconda).

--- a/install-windows.md
+++ b/install-windows.md
@@ -28,7 +28,7 @@ error you are *not* using anaconda).
 Open the command line in the directory of the manuscript 
 (`./manuscript`). Now run the following command:
 
-```sphinx-build -M latexpdf . _build```
+`sphinx-build -M latexpdf . _build`
 
 The compiled .pdf file can be found in 
 `./manuscript/_build/latex/tools4scicomp.pdf`.

--- a/install-windows.md
+++ b/install-windows.md
@@ -13,7 +13,7 @@ To check whether sphinx is installed open the command line
 (Windows + R, type `cmd`). Now start the python console by 
 typing in `python`.
 
-If the code `import sphinx` does not raise an 
+If the code `import sphinx` does not raise a 
 `ModuleNotFoundError` sphinx is installed. You can go on 
 with the section *compile the script*.
 

--- a/install-windows.md
+++ b/install-windows.md
@@ -9,8 +9,9 @@ installation instructions.
 ## Install sphinx
 
 If you do not have sphinx installed please install sphinx.
-To check whether open the command line (Windows + R, type 
-`cmd`). Now start the python console by typing in `python`.
+To check whether sphinx is installed open the command line 
+(Windows + R, type `cmd`). Now start the python console by 
+typing in `python`.
 
 If the code `import sphinx` does not raise an 
 `ModuleNotFoundError` sphinx is installed. You can go on 

--- a/install-windows.md
+++ b/install-windows.md
@@ -30,5 +30,5 @@ Open the command line in the directory of the manuscript
 
 ```sphinx-build -M latexpdf . _build```
 
-The compiled .tex file can be found in 
+The compiled .pdf file can be found in 
 `./manuscript/_build/latex/tools4scicomp.pdf`.

--- a/install-windows.md
+++ b/install-windows.md
@@ -1,0 +1,33 @@
+# How to install on windows
+
+## Install python
+
+If you do not have python installed please install python 
+from https://www.python.org/downloads/ and follow the 
+installation instructions.
+
+## Install sphinx
+
+If you do not have sphinx installed please install sphinx.
+To check whether open the command line (Windows + R, type 
+`cmd`). Now start the python console by typing in `python`.
+
+If the code `import sphinx` does not raise an 
+`ModuleNotFoundError` sphinx is installed. You can go on 
+with the section *compile the script*.
+
+If `sphinx` is not installed run the code 
+`pip install sphinx` (or `conda install sphinx if you have 
+python installed via anaconda. To find out if you are using 
+conda type `conda list` in the command line. If there is an 
+error you are *not* using anaconda).
+
+## Compile the script
+
+Open the command line in the directory of the manuscript 
+(`./manuscript`). Now run the following command:
+
+```sphinx-build -M latexpdf . _build```
+
+The compiled .tex file can be found in 
+`./manuscript/_build/latex/tools4scicomp.pdf`.


### PR DESCRIPTION
This pull request contains only one new file, the `install-windows.md`. This file contains instructions on how to compile the manuscript on a windows computer. Windows computers do not support the `makefile`s, this is why the user has to compile the file manually.

All the following commits are only correcting typos or insert missing words.